### PR TITLE
Get a second parameter for output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Jishnu P, & Singh, Praneet. (2018, October 21). MV-Tractus: A simple tool to ext
 4. `sudo cp ffmpeg.conf /etc/ld.so.conf.d/ffmpeg.conf && sudo ldconfig`
 5. `./compile` OR You can use the compile_command.txt to generate the binary file.
 6. mkdir -p output/mv/
-7. `./extract_mvs <video-file-path>`.
-8. And there you go. The output will be saved in './output/mv/'.
+7. `./extract_mvs <video-file-path> <output-path>`.
+8. And there you go. The output will be saved in `<output-path>`. If this parameter is not specified, then the output is saved in './output/mv/'.
 
 `pip install mv-tractus` (Coming Soon).
 

--- a/extract_mvs.c
+++ b/extract_mvs.c
@@ -40,6 +40,7 @@ static const char *src_filename = NULL;
 static int video_stream_idx = -1;
 static AVFrame *frame = NULL;
 static int video_frame_count = 0;
+static char **output_name = "./output/mv";
 
 static int print_motion_vectors_data(AVMotionVector *mv, int video_frame_count){
   printf("| #:%d | p/f:%2d | %2d x %2d | src:(%4d,%4d) | dst:(%4d,%4d) | dx:%4d | dy:%4d | motion_x:%4d | motion_y:%4d | motion_scale:%4d | 0x%"PRIx64" |\n",
@@ -89,7 +90,7 @@ static int decode_packet(const AVPacket *pkt)
             int i;
             AVFrameSideData *sd;
 	    video_frame_count++;
-            sprintf(szFileName, "./output/mv/%d.json", video_frame_count);
+            sprintf(szFileName, "%s/%d.json", output_name, video_frame_count);
             file = fopen(szFileName,"w");
             if (file == NULL)
             {
@@ -285,5 +286,8 @@ end:
 
 int main(int argc, char **argv)
 {
+	if(argc>2) {
+		output_name = argv[2];
+	}
 	extract_motion_vectors(argv[1]);
 }

--- a/extract_mvs_with_frames.c
+++ b/extract_mvs_with_frames.c
@@ -51,6 +51,7 @@ int               frameFinished;
 int               numBytes;
 uint8_t           *buffer = NULL;
 struct SwsContext *sws_ctx = NULL;
+static char **output_name = "./output/mv";
 
 // compatibility with newer API
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,28,1)
@@ -147,7 +148,7 @@ static int decode_packet(const AVPacket *pkt)
 
             // Save the frame to disk
             SaveFrame(pFrameRGB, pCodecCtx->width, pCodecCtx->height,video_frame_count);
-            sprintf(szFileName, "./output/mv/%d.json", video_frame_count);
+            sprintf(szFileName, "%s/%d.json", output_name, video_frame_count);
             file = fopen(szFileName,"w");
             if (file == NULL)
             {
@@ -379,5 +380,8 @@ end:
 
 int main(int argc, char **argv)
 {
+	if(argc>2) {
+		output_name = argv[2];
+	}
 	extract_motion_vectors(argv[1]);
 }


### PR DESCRIPTION
This will let the user set a second parameter for 'extract_mvs.c'  and 'extract_mvs_with_frames.c' for the output directory. If it is not specified, it defaults to './output/mv/'.